### PR TITLE
Remove dev flags

### DIFF
--- a/gulp/index.js
+++ b/gulp/index.js
@@ -162,19 +162,6 @@ module.exports = {
       throw 'Invalid paths';
     }
 
-    // Support the --builddir or --target options as an override for the build directory.
-    // TODO: Document this.  Should also provide the ability to pass all options and/or paths
-    // via command flags, ie. gulp --paths.build=../public build
-    if (gutil.env.builddir || gutil.env.target) {
-      paths.build = gutil.env.builddir || gutil.env.target;
-    }
-
-    // Finally, if NODE_BUILD_DIR is set, override paths.build
-    // TODO: Document!
-    if (process.env.NODE_BUILD_DIR) {
-      paths.build = process.env.NODE_BUILD_DIR;
-    }
-
     // Helper function to get browserify bundler used both by the 'js' task and the 'watch' task
     var bundlerInstance;
     var bundler = function(watch) {

--- a/less/defaults.less
+++ b/less/defaults.less
@@ -93,7 +93,11 @@ section {
 }
 
 section:first-child {
-  margin: 0;
+  margin-top: 0;
+}
+
+section:last-child {
+  margin-bottom: 0;
 }
 
 code pre {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "syrup",
-  "version": "0.1.14",
+  "version": "0.1.15",
   "description": "A collection of common UI utilities and libraries leveraged by AI2.",
   "homepage": "http://allenai.github.io/syrup/",
   "repository": "allenai/syrup",


### PR DESCRIPTION
Cleanup.  Remove a few flags which aren't documented publicly nor should be supported.  The new `reStart` magic makes these unecessary.

@jkinkead Please review.