### PR TITLE
Fixes #32;

### DIFF
--- a/dev/app/main.jsx
+++ b/dev/app/main.jsx
@@ -6,7 +6,7 @@ class Flapjack extends React.Component {
   render() {
     return (
       <div className="flapjack">
-        <header><h1>What a tasty flapjack!</h1></header>
+        <header><h1>What a tasty flapjack! React {React.version}</h1></header>
         <main>
           <h2>I know, right!?</h2>
           <p>

--- a/dev/gulpfile.js
+++ b/dev/gulpfile.js
@@ -5,10 +5,13 @@ var gutil = require('gulp-util');
 var syrup = require('../');
 var express = require('express');
 var morgan = require('morgan');
+var segfaultHandler = require('segfault-handler');
+
+segfaultHandler.registerHandler();
 
 syrup.gulp.init(gulp);
 
-gulp.task('start-server', function(cb) {
+gulp.task('start-server', ['watch'], function(cb) {
   var server = express();
   server.use(morgan('dev'));
   server.use(express.static('./build'));
@@ -17,5 +20,3 @@ gulp.task('start-server', function(cb) {
     cb();
   });
 });
-
-

--- a/dev/package.json
+++ b/dev/package.json
@@ -12,6 +12,7 @@
     "express": "4.12.3",
     "gulp-util": "3.0.4",
     "morgan": "1.5.2",
-    "react": "0.13.1"
+    "react": "0.13.3",
+    "segfault-handler": "0.2.4"
   }
 }

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
   },
   "dependencies": {
     "babelify": "6.0.1",
-    "browserify": "9.0.3",
+    "browserify": "10.2.4",
     "del": "0.1.3",
     "express": "4.10.1",
     "griddle": "0.1.2",
@@ -47,6 +47,6 @@
     "stringify": "3.1.0",
     "vinyl-buffer": "1.0.0",
     "vinyl-source-stream": "1.1.0",
-    "watchify": "2.4.0"
+    "watchify": "codeviking/watchify"
   }
 }


### PR DESCRIPTION
* Use a forked version of watchify with a patch such that files in
  node_modules don't get watched.
* When a change to package.json is detected, run npm prune and npm
  install as is necessary, then rebundle.
* Add a segfault handler to the dev project for debugging issues.